### PR TITLE
Add activity functionality added

### DIFF
--- a/TimeLog.kv
+++ b/TimeLog.kv
@@ -1,0 +1,164 @@
+#:kivy 1.0
+
+<TimeLog>:
+    id: sm
+
+    Screen:
+        id: title_screen
+        name: "Title Screen"
+        BoxLayout:
+            orientation: 'vertical'
+            Label:
+                id: heading
+                text: "Time Log App"
+                size_hint: 1, .4
+            ScrollView:
+                GridLayout:
+
+                    #This prevents enter_activity_popup from being garbage-collected:
+                    enter_activity_popup: enter_activity_popup.__self__
+                    id: title_screen_gridlayout
+                    size_hint: 1, None
+                    cols: 1
+                    row_default_height: 50
+                    height: self.minimum_height
+                    Popup:
+                        id: enter_activity_popup
+                        title: "Enter Activity Popup"
+                        on_parent:
+                            if self.parent == title_screen_gridlayout: self.parent.remove_widget(self)
+                        BoxLayout:
+                            orientation: 'vertical'
+                            TextInput:
+                                id: new_activity_input
+                                text: "activity"
+                            Button:
+                                text: "Add"
+                                on_release:
+                                    root.add_activity_to_list(new_activity_input.text)
+                                    root.clear_enter_activity_buttons()
+                                    root.populate_enter_activity_buttons()
+                                    
+                                    enter_activity_popup.dismiss()
+
+
+
+                    Button:
+                        text: "Log an Activity"
+                        on_release: sm.current = "Enter Activity Screen"
+                    Button:
+                        text: "Add an Activity"
+                        on_release: title_screen_gridlayout.enter_activity_popup.open()
+                    Button:
+                        text: "View Activity Log"
+                        on_release: sm.current = "Activity Log Screen"
+
+    Screen:
+        id: activity_log_screen
+        name: "Activity Log Screen"
+        BoxLayout:
+            orientation: 'vertical'
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint: 1, .2
+                Label:
+                    id: heading
+                    text: "Activity Log"
+                    size_hint: .8, 1
+                Button:
+                    text: "Back"
+                    size_hint: .2, 1
+                    on_release: sm.current = "Enter Activity Screen"
+
+            ScrollView:
+                GridLayout:
+                    id: activity_log
+                    size_hint: 1, None
+                    cols: 1
+                    row_default_height: 50
+                    height: self.minimum_height
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+                    Label:
+                        text: "activity 1:00-2:30"
+
+    Screen:
+        id: enter_activity_screen
+        name: "Enter Activity Screen"
+        BoxLayout:
+            id: enter_activity_screen_boxlayout
+            orientation: 'vertical'
+            BoxLayout:
+                orientation: 'horizontal'
+                size_hint: 1, .2
+                Label:
+                    id: heading
+                    text: "What will you do?"
+                    size_hint: .8, 1
+                Button:
+                    text: "Back"
+                    size_hint: .2, 1
+                    on_release: sm.current = "Title Screen"
+
+            ScrollView:
+                id: enter_activity_buttons_scrollview
+                GridLayout:
+                    id: enter_activity_buttons
+                    size_hint: 1, None
+                    cols: 2
+                    row_default_height: 50
+                    height: self.minimum_height
+                    Button:
+                        text: "test go to log screen"
+                        on_release: sm.current = "Activity Log Screen"
+                    Button:
+                        text: "activity"
+                    Button:
+                        text: "activity"
+                    Button:
+                        text: "activity"
+                    Button:
+                        text: "activity"
+

--- a/class_structure.py
+++ b/class_structure.py
@@ -112,9 +112,9 @@ class Date():
 class ActivityLog():
     """A list of logged activities."""
 
-    def __init__(self, log_entry_list):
+    def __init__(self):
         """Initialize with log_entry_list (list of LogEntry) attribute."""
-        self.log_entry_list = log_entry_list
+        self.log_entry_list = []
 
     def get_log_entry_list(self):
         """Returns list of LogEntry."""

--- a/main.py
+++ b/main.py
@@ -9,6 +9,9 @@ from kivy.config import Config
 from kivy.uix.screenmanager import Screen
 from kivy.uix.screenmanager import ScreenManager
 
+from class_structure import Activity, ActivityLog, LogEntry
+
+
 class EnterActivityScreen(BoxLayout):
     pass
 
@@ -18,14 +21,36 @@ class ActivityLogScreen(BoxLayout):
 class TitleScreen(BoxLayout):
     pass
 
-class ActivityLog(ScreenManager):
-    pass
+class TimeLog(ScreenManager):
+    def __init__(self, **kwargs):
+        super(TimeLog, self).__init__(**kwargs)
+        self.activity_log = ActivityLog()
+        self.activity_list = []
+        self.enter_activity_buttons = self.ids['enter_activity_buttons']
+
+    def add_activity_to_list(self, new_activity_name):
+        for activity in self.activity_list:
+            if activity.get_name() == new_activity_name:
+                #Exits method.  The named activity is already in the list of activities.
+                return
+
+        self.activity_list.append(Activity(new_activity_name))
+
+    def populate_enter_activity_buttons(self):
+        for activity in self.activity_list:
+            new_button = Button(text = activity.get_name())
+            self.enter_activity_buttons.add_widget(new_button)
+
+    def clear_enter_activity_buttons(self):
+        self.enter_activity_buttons.clear_widgets()
 
 
-class ActivityLogApp(App):
+
+
+class TimeLogApp(App):
     """The main app."""
     def build(self):
-        return ActivityLog()
+        return TimeLog()
 
 if __name__ == '__main__':
-    ActivityLogApp().run()
+    TimeLogApp().run()


### PR DESCRIPTION
Changes include: Add Activity button on title screen now displays a
popup on which a new activity can be entered; activities entered with
said popup are added to TimeLog's activity_list; whenever the "Add"
button on the popup is pressed, the Enter Activity Screen is cleared of
activity buttons and then populated with a button for each activity in
TimeLog's activity_list.